### PR TITLE
Update StandardController.php

### DIFF
--- a/app/code/local/Mage/Epay/controllers/StandardController.php
+++ b/app/code/local/Mage/Epay/controllers/StandardController.php
@@ -90,11 +90,11 @@ class Mage_Epay_StandardController extends Mage_Core_Controller_Front_Action
 			{
 				$quote = Mage::getModel('sales/quote')->load($lastQuoteId);
 				$quote->setIsActive(true)->save();
-				$orderModel->cancel();
+				/*$orderModel->cancel();
 				$orderModel->setStatus('canceled');
 				$orderModel->save();
 				Mage::getSingleton('core/session')->setFailureMsg('order_failed');
-				Mage::getSingleton('checkout/session')->setFirstTimeChk('0');
+				Mage::getSingleton('checkout/session')->setFirstTimeChk('0');*/
 			}
 		}
 		


### PR DESCRIPTION
When cancelling an order, the customer can use the back button in the browser, and finalize the payment anyways. This will set the order in the "processing" state, but will leave the product items in the cancelled state, rendering the order useless. Store owners cannot cancel or finalize the order through the backend, and MySQL work is required to cancel the order completely.

This way, the order is left in "pending" state if the customer doesn't pay - and in "processing" state with "working" product items if the customer uses the back button and pays anyways.
