### PR TITLE
Update redirect_standardwindow.phtml

### DIFF
--- a/app/design/frontend/base/default/template/epay/standard/redirect_standardwindow.phtml
+++ b/app/design/frontend/base/default/template/epay/standard/redirect_standardwindow.phtml
@@ -98,14 +98,5 @@ document.onreadystatechange = function () {
 		<label for="CurrencyAmount"><?php echo $order->getBaseCurrency()->getCode() ?>&nbsp;<?php echo number_format($order->getBaseTotalDue(), 2, ',', ' ') ?></label>
 	</td>
 	</tr>
-	<tr>
-		<td colspan="2">
-			<br>
-			<input type="button" value="<?php echo $this->__('EPAY_LABEL_35') ?>" onclick="javascript: paymentwindow.open();"> <br><br>
-			<br />
-			<?php echo $this->__('EPAY_LABEL_33') ?> <br><br>
-			<br />
-			<input name="paymentCancel" id="paymentCancel" value="<?php echo $this->__('EPAY_LABEL_100') ?>" type="button" class="form-button-alt" onclick="javascript:location='<?php echo $cancelurl; ?>'" />	
-		</td>
-	</tr>
+
 </table>


### PR DESCRIPTION
Removing the cancel option when closing the payment window. It's an addition to the suggested fix to StandardController.php to ensure that no orders are rendered useless, even if the end user is "misbehaving" and using the back button in the browser.
