### PR TITLE
Update StandardController.php

### DIFF
--- a/app/code/local/Mage/Epay/controllers/StandardController.php
+++ b/app/code/local/Mage/Epay/controllers/StandardController.php
@@ -32,8 +32,9 @@ class Mage_Epay_StandardController extends Mage_Core_Controller_Front_Action
 
         $payment = $order->getPayment();
         $pspReference = $payment->getAdditionalInformation(Mage_Epay_Model_Standard::PSP_REFERENCE);
+	$lastSuccessQuoteId = $session->getLastSuccessQuoteId();
 
-        if(!empty($pspReference) || empty($session->getLastSuccessQuoteId()))
+        if(!empty($pspReference) || empty($lastSuccessQuoteId))
         {
             $this->_redirect('checkout/onepage/success');
             return;


### PR DESCRIPTION
Understøttelse af PHP < v. 5.5

ref. http://php.net/manual/en/function.empty.php
5.5.0 	empty() now supports expressions, rather than only variables.