### PR TITLE
Delete failed orders

### DIFF
--- a/app/code/local/Mage/Epay/Model/Observer.php
+++ b/app/code/local/Mage/Epay/Model/Observer.php
@@ -121,7 +121,7 @@ class Mage_Epay_Model_Observer
                     $read = Mage::getSingleton('core/resource')->getConnection('core_read');
                     $row = $read->fetchRow("select * from epay_order_status where orderid = '" . $orderModel->getIncrementId() . "'");
 
-                    if ($row["status"] == '0') {
+                    if (!$row || $row["status"] == '0') {
                         $orderModel->cancel();
                         $message = Mage::helper('epay')->__("Order was auto canceled because no payment has been made.");
                         $orderModel->addStatusToHistory($orderModel->getStatus(), $message);


### PR DESCRIPTION
I situationer hvor der er javascript der fejler i checkout, kan der bliver oprettet ordrer, hvor kunden aldrig bliver viderestillet til epay. Disse ordrer bliver ikke slettet automatisk da der ikke bliver sat en status på dem.

Det oprindelige problem skal selvfølgelig løses, men denne ændring vil gøre at Epay modulet kan slette ordrer hvor kunden har forsøgt at godkende ordren, men af den ene eller anden grund ikke bliver viderestillet til epay. 